### PR TITLE
Correct order of btn rules

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -164,7 +164,7 @@ export const presetDaisy = (
 					new RegExp(`^${base}$`),
 					() => replaceSlash(replacePrefix(rule)),
 					{
-						layer: base.startsWith('checkbox-')
+						layer: base.startsWith('checkbox-') || base.startsWith('btn-circle') || base.startsWith('btn-square')
 							? 'daisy-components-post'
 							: 'daisy-components',
 					},


### PR DESCRIPTION
Fixes a discrepancy between DaisyUI with TW.

Currently, `.btn-xs` and othere size rules comes later than `.btn-circle`/`.btn-square`. This makes e.g. `.btn-square:where(.btn-xs)` produce a different padding due to cascade.

To solve this and improve compatability with regular Daisy, this PR adds square/circle buttons to a layer that comes after components. The end result is that left/right padding is correctly set to `0` instead of `0.5rem`.

### Before
![image](https://github.com/csvn/unocss-preset-daisy/assets/8770194/d08a6eee-0df2-43f9-841d-6983ac176cd5)

### After
![image](https://github.com/csvn/unocss-preset-daisy/assets/8770194/db64fc58-f576-4bd4-942f-dfdfd9ab71b4)